### PR TITLE
LRQA-30892 New jenkins report

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
@@ -518,6 +518,11 @@ public abstract class BaseBuild implements Build {
 	}
 
 	@Override
+	public Element getJenkinsReportElement() {
+		return null;
+	}
+
+	@Override
 	public String getJobName() {
 		return jobName;
 	}
@@ -671,6 +676,8 @@ public abstract class BaseBuild implements Build {
 	@Override
 	public Long getStartTimestamp() {
 		JSONObject buildJSONObject = getBuildJSONObject("timestamp");
+
+		//System.out.println(buildJSONObject.toString());
 
 		if (buildJSONObject == null) {
 			return null;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/Build.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/Build.java
@@ -74,6 +74,8 @@ public interface Build {
 
 	public String getJDK();
 
+	public Element getJenkinsReportElement();
+
 	public String getJobName();
 
 	public String getJobURL();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsReportUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsReportUtil.java
@@ -1,0 +1,156 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import org.dom4j.Element;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @author Kenji Heigel
+ */
+public class JenkinsReportUtil {
+	public static Element getTimelineElement(
+		Build topLevelBuild, Map<String, Build> builds) {
+
+		long topLevelDuration = topLevelBuild.getDuration();
+		long topLevelStartTime = topLevelBuild.getStartTimestamp();
+
+		int dataPoints = 500;
+
+		long[] invocationData = new long[dataPoints];
+		long[] slaveUsageData = new long[dataPoints];
+
+		for (String key : builds.keySet()) {
+			Build build = builds.get(key);
+
+			long buildDuration = build.getDuration();
+			long buildStartTime = build.getStartTimestamp();
+
+			long buildEndTime = buildDuration + buildStartTime;
+
+			long dataEnd =
+				(buildEndTime - topLevelStartTime) * dataPoints /
+					topLevelDuration;
+			long dataStart =
+				(buildStartTime - topLevelStartTime) * dataPoints /
+					topLevelDuration;
+
+			for (int i = (int)dataStart; i < dataEnd; i++) {
+				slaveUsageData[i] = ++slaveUsageData[i];
+			}
+
+			invocationData[(int)dataStart] = ++invocationData[(int)dataStart];
+		}
+
+		long[] timeData = new long[dataPoints];
+
+//		timeData[0] = topLevelStartTime;
+		timeData[0] = 0;
+
+		for (int i = 1; i < timeData.length; i++) {
+			timeData[i] = timeData[0] + i * topLevelDuration / dataPoints ;
+		}
+
+		Element canvasElement = Dom4JUtil.getNewElement("canvas");
+
+		canvasElement.addAttribute("height", "300");
+		canvasElement.addAttribute("id", "timeline");
+
+		Element scriptElement = Dom4JUtil.getNewElement("script");
+
+		scriptElement.addAttribute("src", _CHART_JS_FILE);
+		scriptElement.addText("");
+
+		Element chartJSScriptElement =
+			getChartJSScriptElement(
+				Arrays.toString(timeData), Arrays.toString(slaveUsageData),
+				Arrays.toString(invocationData));
+
+		Element divElement = Dom4JUtil.getNewElement("div");
+
+		Dom4JUtil.addToElement(
+			divElement, canvasElement, scriptElement, chartJSScriptElement);
+
+		return divElement;
+	}
+
+	public static Element getBasicHeaderElement(
+	Build topLevelBuild, Map<String, Build> builds) {
+
+		long totalTime = 0;
+
+		for (Build axisBuild : builds.values()) {
+			totalTime = totalTime + axisBuild.getDuration();
+		}
+
+		Element divElement = Dom4JUtil.getNewElement("div");
+
+		long hoursTotalTime = totalTime / 3600000;
+
+		divElement.addText(
+			"Total CI Usage: " + hoursTotalTime + " server hours");
+
+		return divElement;
+	}
+
+	public static Element getBatchReportElement(
+		Build topLevelBuild, Map<String, Build> builds) {
+
+		Set<String> buildsKeySet = builds.keySet();
+
+		for (String key : buildsKeySet) {
+			Build build = builds.get(key);
+
+			long buildDuration = build.getDuration();
+			long buildStartTime = build.getStartTimestamp();
+
+			long buildEndTime = buildDuration + buildStartTime;
+		}
+
+		return null;
+	}
+
+	public static Element getChartJSScriptElement(
+		String xData, String y1Data, String y2Data) {
+
+		String resource = null;
+
+		try {
+			Class<?> clazz = JenkinsResultsParserUtil.class;
+
+			resource = JenkinsResultsParserUtil.readInputStream(
+			clazz.getResourceAsStream("chart-template.js"));
+		}
+		catch (IOException ioe) {
+		}
+
+		resource = resource.replace("'xData'", xData);
+		resource = resource.replace("'y1Data'", y1Data);
+		resource = resource.replace("'y2Data'", y2Data);
+
+		Element scriptElement = Dom4JUtil.getNewElement("script");
+
+		scriptElement.addText(resource);
+
+		return scriptElement;
+	}
+
+	private static final String _CHART_JS_FILE =
+		"https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.5.0/Chart.min.js";
+}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsReportUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsReportUtil.java
@@ -164,15 +164,9 @@ public class JenkinsReportUtil {
 			String axisName = JenkinsResultsParserUtil.combine(
 				"AXIS_VARIABLE=", axisBuild.getAxisNumber());
 
-			Element trAxisInfoElement = Dom4JUtil.getNewElement(
-				"tr", tableElement);
-
-			List<Element> axisInfoElements = getCommonBuildInfoElementList(
-				build, axisName, "td");
-
-			for (Element axisInfoElement : axisInfoElements) {
-				trAxisInfoElement.add(axisInfoElement);
-			}
+			Dom4JUtil.getNewElement(
+				"tr", tableElement,
+				(Object[])getCommonBuildInfoElements(build, axisName, "td"));
 		}
 	}
 
@@ -202,10 +196,9 @@ public class JenkinsReportUtil {
 
 			Element trBatchElement = Dom4JUtil.getNewElement("tr");
 
-			List<Element> batchInfoElements = getCommonBuildInfoElementList(
-				batchBuild, batchName, "th");
+			for (Element batchInfoElement : getCommonBuildInfoElements(
+					batchBuild, batchName, "th")) {
 
-			for (Element batchInfoElement : batchInfoElements) {
 				trBatchElement.add(batchInfoElement);
 			}
 
@@ -342,78 +335,66 @@ public class JenkinsReportUtil {
 		return scriptElement;
 	}
 
-	protected static List<Element> getCommonBuildInfoElementList(
-		Build build, String buildName, String elementTag) {
+	protected static Element[] getCommonBuildInfoElements(
+		Build build, String buildName, String tagName) {
 
 		String buildURL = build.getBuildURL();
 
 		String buildConsoleURL = buildURL + "console";
 
-		String buildTestReportURL = buildURL + "testReport";
+		List<Element> elements = new ArrayList<>();
 
-		long buildDuration = build.getDuration();
+		elements.add(
+			Dom4JUtil.getNewElement(
+				tagName, null,
+				Dom4JUtil.getNewAnchorElement(
+					buildConsoleURL, null, "Console")));
+
+		elements.add(
+			Dom4JUtil.getNewElement(
+				tagName, null,
+				JenkinsResultsParserUtil.toDurationString(
+					build.getDuration())));
+
+		elements.add(
+			Dom4JUtil.getNewElement(
+				tagName, null,
+				Dom4JUtil.getNewAnchorElement(buildURL, null, buildName)));
 
 		Date buildStartDate = new Date(build.getStartTimestamp());
 
-		Element buildConsoleElement = Dom4JUtil.getNewElement(
-			elementTag, null,
-			Dom4JUtil.getNewAnchorElement(buildConsoleURL, null, "Console"));
+		elements.add(
+			Dom4JUtil.getNewElement(
+				tagName, null, buildStartDate.toLocaleString()));
 
-		Element buildDurationElement = Dom4JUtil.getNewElement(
-			elementTag, null,
-			JenkinsResultsParserUtil.toDurationString(buildDuration));
+		String buildTestReportURL = buildURL + "testReport";
 
-		Element buildNameElement = Dom4JUtil.getNewElement(
-			elementTag, null,
-			Dom4JUtil.getNewAnchorElement(buildURL, null, buildName));
-
-		Element buildStartTimeElement = Dom4JUtil.getNewElement(
-			elementTag, null, buildStartDate.toLocaleString());
-
-		Element buildTestReportElement = Dom4JUtil.getNewElement(
-			elementTag, null,
-			Dom4JUtil.getNewAnchorElement(
-				buildTestReportURL, null, "Test Report"));
-
-		Element buildStatusElement = Dom4JUtil.getNewElement(elementTag);
+		elements.add(
+			Dom4JUtil.getNewElement(
+				tagName, null,
+				Dom4JUtil.getNewAnchorElement(
+					buildTestReportURL, null, "Test Report")));
 
 		String status = build.getStatus();
 
 		if (status != null) {
-			buildStatusElement.addText(StringUtils.upperCase(status));
+			status = StringUtils.upperCase(status);
 		}
 		else {
-			buildStatusElement.addText("");
+			status = "";
 		}
 
-		Element buildResultElement = Dom4JUtil.getNewElement(elementTag);
+		elements.add(Dom4JUtil.getNewElement(tagName, null, status));
 
 		String result = build.getResult();
 
-		if (result != null) {
-			buildResultElement.addText(result);
-		}
-		else {
-			buildResultElement.addText("");
+		if (result == null) {
+			result = "";
 		}
 
-		List<Element> elementList = new ArrayList();
+		elements.add(Dom4JUtil.getNewElement(tagName, null, result));
 
-		elementList.add(buildNameElement);
-
-		elementList.add(buildConsoleElement);
-
-		elementList.add(buildTestReportElement);
-
-		elementList.add(buildStartTimeElement);
-
-		elementList.add(buildDurationElement);
-
-		elementList.add(buildStatusElement);
-
-		elementList.add(buildResultElement);
-
-		return elementList;
+		return elements.toArray(new Element[elements.size()]);
 	}
 
 	protected static Element getLongestAxisElement(
@@ -738,10 +719,9 @@ public class JenkinsReportUtil {
 
 		Element trTopLevelElement = Dom4JUtil.getNewElement("tr");
 
-		List<Element> topLevelInfoElements = getCommonBuildInfoElementList(
-			topLevelBuild, topLevelName, "th");
+		for (Element topLevelInfoElement : getCommonBuildInfoElements(
+				topLevelBuild, topLevelName, "th")) {
 
-		for (Element topLevelInfoElement : topLevelInfoElements) {
 			trTopLevelElement.add(topLevelInfoElement);
 		}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsReportUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsReportUtil.java
@@ -106,6 +106,86 @@ public class JenkinsReportUtil {
 		return headElement;
 	}
 
+	protected static void addAxisInfoToTableElement(
+		List<Build> axisBuilds, Element tableElement) {
+
+		for (Build axisBuild : axisBuilds) {
+			String axisName =
+				"AXIS_VARIABLE=" + ((AxisBuild)axisBuild).getAxisNumber();
+
+			String axisBuildURL = axisBuild.getBuildURL();
+
+			String axisConsoleURL = axisBuildURL + "console";
+
+			String axisTestReportURL = axisBuildURL + "testReport";
+
+			long axisDuration = axisBuild.getDuration();
+
+			String axisDurationString =
+				JenkinsResultsParserUtil.toDurationString(axisDuration);
+
+			long axisStartTime = axisBuild.getStartTimestamp();
+
+			Date axisStartDate = new Date(axisStartTime);
+
+			String status = axisBuild.getStatus();
+
+			String result = axisBuild.getResult();
+
+			Element axisNameElement = Dom4JUtil.getNewAnchorElement(
+				axisBuildURL, null, axisName);
+
+			Element axisConsoleElement = Dom4JUtil.getNewAnchorElement(
+				axisConsoleURL, null, "Console");
+
+			Element axisTestReportElement = Dom4JUtil.getNewAnchorElement(
+				axisTestReportURL, null, "Test Report");
+
+			Element tdAxisNameElement = Dom4JUtil.getNewElement("td");
+
+			tdAxisNameElement.add(axisNameElement);
+
+			Element tdAxisConsoleElement = Dom4JUtil.getNewElement("td");
+
+			tdAxisConsoleElement.add(axisConsoleElement);
+
+			Element tdAxisTestReportElement = Dom4JUtil.getNewElement("td");
+
+			tdAxisTestReportElement.add(axisTestReportElement);
+
+			Element tdStartTimeStringElement = Dom4JUtil.getNewElement(
+				"td", null, "START TIME:");
+
+			Element tdStartTimeElement = Dom4JUtil.getNewElement(
+				"td", null, axisStartDate.toLocaleString());
+
+			Element tdBuildTimeStringElement = Dom4JUtil.getNewElement(
+				"td", null, "BUILD TIME:");
+
+			Element tdBuildTimeElement = Dom4JUtil.getNewElement(
+				"td", null, axisDurationString);
+
+			Element tdStatusResultElement = Dom4JUtil.getNewElement("td");
+
+			if (result != null) {
+				tdStatusResultElement.addText(result);
+			}
+			else {
+				tdStatusResultElement.addText(status);
+			}
+
+			Element trAxisInfoElement = Dom4JUtil.getNewElement("tr");
+
+			Dom4JUtil.addToElement(
+				trAxisInfoElement, tdAxisNameElement, tdAxisConsoleElement,
+				tdAxisTestReportElement, tdStartTimeStringElement,
+				tdStartTimeElement, tdBuildTimeStringElement,
+				tdBuildTimeElement, tdStatusResultElement);
+
+			tableElement.add(trAxisInfoElement);
+		}
+	}
+
 	protected static Element getBatchInfoTableElement(
 		List<Build> batchBuilds, String statusCountCaption) {
 
@@ -196,6 +276,10 @@ public class JenkinsReportUtil {
 				thBuildTimeElement, thStatusResultElement);
 
 			tableElement.add(trBatchElement);
+
+			List<Build> axisBuilds = batchBuild.getDownstreamBuilds(null);
+
+			addAxisInfoToTableElement(axisBuilds, tableElement);
 		}
 
 		return tableElement;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsReportUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsReportUtil.java
@@ -24,6 +24,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 
+import org.apache.commons.lang.StringUtils;
+
 import org.dom4j.Element;
 
 import org.json.JSONObject;
@@ -407,6 +409,80 @@ public class JenkinsReportUtil {
 		scriptElement.addText(resource);
 
 		return scriptElement;
+	}
+
+	protected static List<Element> getCommonBuildInfoElementList(
+		Build build, String buildName, String elementTag) {
+
+		String buildURL = build.getBuildURL();
+
+		String buildConsoleURL = buildURL + "console";
+
+		String buildTestReportURL = buildURL + "testReport";
+
+		long buildDuration = build.getDuration();
+
+		Date buildStartDate = new Date(build.getStartTimestamp());
+
+		Element buildConsoleElement = Dom4JUtil.getNewElement(
+			elementTag, null,
+			Dom4JUtil.getNewAnchorElement(buildConsoleURL, null, "Console"));
+
+		Element buildDurationElement = Dom4JUtil.getNewElement(
+			elementTag, null,
+			JenkinsResultsParserUtil.toDurationString(buildDuration));
+
+		Element buildNameElement = Dom4JUtil.getNewElement(
+			elementTag, null,
+			Dom4JUtil.getNewAnchorElement(buildURL, null, buildName));
+
+		Element buildStartTimeElement = Dom4JUtil.getNewElement(
+			elementTag, null, buildStartDate.toLocaleString());
+
+		Element buildTestReportElement = Dom4JUtil.getNewElement(
+			elementTag, null,
+			Dom4JUtil.getNewAnchorElement(
+				buildTestReportURL, null, "Test Report"));
+
+		Element buildStatusElement = Dom4JUtil.getNewElement(elementTag);
+
+		String status = build.getStatus();
+
+		if (status != null) {
+			buildStatusElement.addText(StringUtils.upperCase(status));
+		}
+		else {
+			buildStatusElement.addText("");
+		}
+
+		Element buildResultElement = Dom4JUtil.getNewElement(elementTag);
+
+		String result = build.getResult();
+
+		if (result != null) {
+			buildResultElement.addText(result);
+		}
+		else {
+			buildResultElement.addText("");
+		}
+
+		List<Element> elementList = new ArrayList();
+
+		elementList.add(buildNameElement);
+
+		elementList.add(buildConsoleElement);
+
+		elementList.add(buildTestReportElement);
+
+		elementList.add(buildStartTimeElement);
+
+		elementList.add(buildDurationElement);
+
+		elementList.add(buildStatusElement);
+
+		elementList.add(buildResultElement);
+
+		return elementList;
 	}
 
 	protected static Element getLongestAxisElement(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsReportUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsReportUtil.java
@@ -151,25 +151,6 @@ public class JenkinsReportUtil {
 		return headElement;
 	}
 
-	protected static void addAxisInfoToTableElement(
-		List<Build> builds, Element tableElement) {
-
-		for (Build build : builds) {
-			if (!(build instanceof AxisBuild)) {
-				continue;
-			}
-
-			AxisBuild axisBuild = (AxisBuild)build;
-
-			String axisName = JenkinsResultsParserUtil.combine(
-				"AXIS_VARIABLE=", axisBuild.getAxisNumber());
-
-			Dom4JUtil.getNewElement(
-				"tr", tableElement,
-				(Object[])getCommonBuildInfoElements(build, axisName, "td"));
-		}
-	}
-
 	protected static Element getBatchInfoTableElement(
 		List<Build> batchBuilds, String statusCountCaption) {
 
@@ -204,9 +185,9 @@ public class JenkinsReportUtil {
 
 			tableElement.add(trBatchElement);
 
-			List<Build> axisBuilds = batchBuild.getDownstreamBuilds(null);
-
-			addAxisInfoToTableElement(axisBuilds, tableElement);
+			Dom4JUtil.addToElement(
+				tableElement,
+				(Object[])getDownstreamBuildInfoElements(batchBuild.getDownstreamBuilds(null)));
 		}
 
 		return tableElement;
@@ -398,6 +379,30 @@ public class JenkinsReportUtil {
 		return elements.toArray(new Element[elements.size()]);
 	}
 
+	protected static Element[] getDownstreamBuildInfoElements(
+		List<Build> downstreamBuilds) {
+
+		List<Element> elements = new ArrayList<>(downstreamBuilds.size());
+
+		for (Build build : downstreamBuilds) {
+			if (!(build instanceof AxisBuild)) {
+				continue;
+			}
+
+			AxisBuild axisBuild = (AxisBuild)build;
+
+			String axisName = JenkinsResultsParserUtil.combine(
+				"AXIS_VARIABLE=", axisBuild.getAxisNumber());
+
+			elements.add(
+				Dom4JUtil.getNewElement(
+					"tr", null,
+					(Object[])getCommonBuildInfoElements(build, axisName, "td")));
+		}
+
+		return elements.toArray(new Element[elements.size()]);
+	}
+
 	protected static Element getLongestAxisElement(
 		Map<String, Build> axisBuilds) {
 
@@ -423,7 +428,7 @@ public class JenkinsReportUtil {
 
 				String axisNumber = ((AxisBuild)axisBuild).getAxisNumber();
 
-				longestAxisName = "AXIS_VARAIBLE=" + axisNumber;
+				longestAxisName = "AXIS_VARIABLE=" + axisNumber;
 
 				longestAxisParentName =
 					axisBuild.getParentBuild().getDisplayName();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsReportUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsReportUtil.java
@@ -137,6 +137,10 @@ public class JenkinsReportUtil {
 		tableElement.add(
 			Dom4JUtil.getNewElement("caption", null, statusCountCaption));
 
+		if (!batchBuilds.isEmpty()) {
+			tableElement.add(getTableColumnHeaderElement());
+		}
+
 		for (Build batchBuild : batchBuilds) {
 			String jobName = batchBuild.getJobName();
 
@@ -673,8 +677,11 @@ public class JenkinsReportUtil {
 			topLevelTableElement.add(
 				Dom4JUtil.getNewElement(
 					"caption", null,
-					"Top Level Build - <strong>" + status + "</strong>"));
+					"Top Level Build - <strong>" +
+						StringUtils.upperCase(status) + "</strong>"));
 		}
+
+		topLevelTableElement.add(getTableColumnHeaderElement());
 
 		String jobName = topLevelBuild.getJobName();
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsReportUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsReportUtil.java
@@ -159,11 +159,13 @@ public class JenkinsReportUtil {
 				continue;
 			}
 
-			String axisName = "AXIS_VARIABLE=";
+			AxisBuild axisBuild = (AxisBuild)build;
 
-			axisName = axisName + ((AxisBuild)build).getAxisNumber();
+			String axisName = JenkinsResultsParserUtil.combine(
+				"AXIS_VARIABLE=", axisBuild.getAxisNumber());
 
-			Element trAxisInfoElement = Dom4JUtil.getNewElement("tr");
+			Element trAxisInfoElement = Dom4JUtil.getNewElement(
+				"tr", tableElement);
 
 			List<Element> axisInfoElements = getCommonBuildInfoElementList(
 				build, axisName, "td");
@@ -171,8 +173,6 @@ public class JenkinsReportUtil {
 			for (Element axisInfoElement : axisInfoElements) {
 				trAxisInfoElement.add(axisInfoElement);
 			}
-
-			tableElement.add(trAxisInfoElement);
 		}
 	}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsReportUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsReportUtil.java
@@ -95,6 +95,7 @@ public class JenkinsReportUtil {
 			getSummaryElement(
 				topLevelBuild, axisBuilds, batchBuilds, testResults),
 			getTimelineElement(topLevelBuild, axisBuilds),
+			getTopLevelTableElement(topLevelBuild),
 			getBatchReportElement(batchBuilds));
 
 		return bodyElement;
@@ -669,6 +670,102 @@ public class JenkinsReportUtil {
 			divElement, canvasElement, scriptElement, chartJSScriptElement);
 
 		return divElement;
+	}
+
+	protected static Element getTopLevelTableElement(Build topLevelBuild) {
+		Element topLevelTableElement = Dom4JUtil.getNewElement("table");
+
+		String status = topLevelBuild.getStatus();
+
+		String result = topLevelBuild.getResult();
+
+		if (result != null) {
+			topLevelTableElement.add(
+				Dom4JUtil.getNewElement(
+					"caption", null,
+					"Top Level Build - <strong>" + result + "</strong>"));
+		}
+		else {
+			topLevelTableElement.add(
+				Dom4JUtil.getNewElement(
+					"caption", null,
+					"Top Level Build - <strong>" + status + "</strong>"));
+		}
+
+		String jobName = topLevelBuild.getJobName();
+
+		String topLevelName = topLevelBuild.getDisplayName();
+
+		topLevelName = topLevelName.replace(jobName + "/", "");
+
+		String topLevelBuildURL = topLevelBuild.getBuildURL();
+
+		String topLevelConsoleURL = topLevelBuildURL + "console";
+
+		String topLevelTestReportURL = topLevelBuildURL + "testReport";
+
+		long topLevelDuration = topLevelBuild.getDuration();
+
+		String topLevelDurationString =
+			JenkinsResultsParserUtil.toDurationString(topLevelDuration);
+
+		long topLevelStartTime = topLevelBuild.getStartTimestamp();
+
+		Date topLevelStartDate = new Date(topLevelStartTime);
+
+		Element topLevelNameElement = Dom4JUtil.getNewAnchorElement(
+			topLevelBuildURL, null, topLevelName);
+
+		Element topLevelConsoleElement = Dom4JUtil.getNewAnchorElement(
+			topLevelConsoleURL, null, "Console");
+
+		Element topLevelTestReportElement = Dom4JUtil.getNewAnchorElement(
+			topLevelTestReportURL, null, "Test Report");
+
+		Element thTopLevelNameElement = Dom4JUtil.getNewElement("th");
+
+		thTopLevelNameElement.add(topLevelNameElement);
+
+		Element thTopLevelConsoleElement = Dom4JUtil.getNewElement("th");
+
+		thTopLevelConsoleElement.add(topLevelConsoleElement);
+
+		Element thTestReportElement = Dom4JUtil.getNewElement("th");
+
+		thTestReportElement.add(topLevelTestReportElement);
+
+		Element thStartTimeStringElement = Dom4JUtil.getNewElement(
+			"th", null, "START TIME:");
+
+		Element thStartTimeElement = Dom4JUtil.getNewElement(
+			"th", null, topLevelStartDate.toLocaleString());
+
+		Element thBuildTimeStringElement = Dom4JUtil.getNewElement(
+			"th", null, "BUILD TIME:");
+
+		Element thBuildTimeElement = Dom4JUtil.getNewElement(
+			"th", null, topLevelDurationString);
+
+		Element thStatusResultElement = Dom4JUtil.getNewElement("th");
+
+		if (result != null) {
+			thStatusResultElement.addText(result);
+		}
+		else {
+			thStatusResultElement.addText(status);
+		}
+
+		Element trTopLevelElement = Dom4JUtil.getNewElement("tr");
+
+		Dom4JUtil.addToElement(
+			trTopLevelElement, thTopLevelNameElement, thTopLevelConsoleElement,
+			thTestReportElement, thStartTimeStringElement, thStartTimeElement,
+			thBuildTimeStringElement, thBuildTimeElement,
+			thStatusResultElement);
+
+		topLevelTableElement.add(trTopLevelElement);
+
+		return topLevelTableElement;
 	}
 
 	protected static Element getTotalCIUsageElement(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsReportUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsReportUtil.java
@@ -106,6 +106,45 @@ public class JenkinsReportUtil {
 	public static Element getHTMLHeadElement() {
 		Element headElement = Dom4JUtil.getNewElement("head");
 
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("caption, table, td, th {");
+
+		sb.append("text-align: left;");
+
+		sb.append("padding: .5em;");
+
+		sb.append("white-space: nowrap;");
+
+		sb.append("}");
+
+		sb.append("th:first-child {");
+
+		sb.append("text-indent: 1em;");
+
+		sb.append("}");
+
+		sb.append("td:first-child {");
+
+		sb.append("text-indent: 4em;");
+
+		sb.append("}");
+
+		sb.append("td {");
+
+		sb.append("}");
+
+		sb.append("caption {");
+
+		sb.append("font-size: 150%;");
+
+		sb.append("font-weight: bold;");
+
+		sb.append("}");
+
+		Dom4JUtil.addToElement(
+			headElement, Dom4JUtil.getNewElement("style", null, sb.toString()));
+
 		return headElement;
 	}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsReportUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsReportUtil.java
@@ -365,7 +365,8 @@ public class JenkinsReportUtil {
 
 		elements.add(
 			Dom4JUtil.getNewElement(
-				tagName, null, buildStartDate.toLocaleString()));
+				tagName, null,
+				JenkinsResultsParserUtil.toDateString(buildStartDate)));
 
 		String buildTestReportURL = buildURL + "testReport";
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsReportUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsReportUtil.java
@@ -116,74 +116,14 @@ public class JenkinsReportUtil {
 			String axisName =
 				"AXIS_VARIABLE=" + ((AxisBuild)axisBuild).getAxisNumber();
 
-			String axisBuildURL = axisBuild.getBuildURL();
-
-			String axisConsoleURL = axisBuildURL + "console";
-
-			String axisTestReportURL = axisBuildURL + "testReport";
-
-			long axisDuration = axisBuild.getDuration();
-
-			String axisDurationString =
-				JenkinsResultsParserUtil.toDurationString(axisDuration);
-
-			long axisStartTime = axisBuild.getStartTimestamp();
-
-			Date axisStartDate = new Date(axisStartTime);
-
-			String status = axisBuild.getStatus();
-
-			String result = axisBuild.getResult();
-
-			Element axisNameElement = Dom4JUtil.getNewAnchorElement(
-				axisBuildURL, null, axisName);
-
-			Element axisConsoleElement = Dom4JUtil.getNewAnchorElement(
-				axisConsoleURL, null, "Console");
-
-			Element axisTestReportElement = Dom4JUtil.getNewAnchorElement(
-				axisTestReportURL, null, "Test Report");
-
-			Element tdAxisNameElement = Dom4JUtil.getNewElement("td");
-
-			tdAxisNameElement.add(axisNameElement);
-
-			Element tdAxisConsoleElement = Dom4JUtil.getNewElement("td");
-
-			tdAxisConsoleElement.add(axisConsoleElement);
-
-			Element tdAxisTestReportElement = Dom4JUtil.getNewElement("td");
-
-			tdAxisTestReportElement.add(axisTestReportElement);
-
-			Element tdStartTimeStringElement = Dom4JUtil.getNewElement(
-				"td", null, "START TIME:");
-
-			Element tdStartTimeElement = Dom4JUtil.getNewElement(
-				"td", null, axisStartDate.toLocaleString());
-
-			Element tdBuildTimeStringElement = Dom4JUtil.getNewElement(
-				"td", null, "BUILD TIME:");
-
-			Element tdBuildTimeElement = Dom4JUtil.getNewElement(
-				"td", null, axisDurationString);
-
-			Element tdStatusResultElement = Dom4JUtil.getNewElement("td");
-
-			if (result != null) {
-				tdStatusResultElement.addText(result);
-			}
-			else {
-				tdStatusResultElement.addText(status);
-			}
-
 			Element trAxisInfoElement = Dom4JUtil.getNewElement("tr");
 
-			Dom4JUtil.addToElement(
-				trAxisInfoElement, tdAxisNameElement, tdAxisConsoleElement,
-				tdAxisTestReportElement, tdStartTimeStringElement,
-				tdStartTimeElement, tdBuildTimeStringElement,
-				tdBuildTimeElement, tdStatusResultElement);
+			List<Element> axisInfoElements = getCommonBuildInfoElementList(
+				axisBuild, axisName, "td");
+
+			for (Element axisInfoElement : axisInfoElements) {
+				trAxisInfoElement.add(axisInfoElement);
+			}
 
 			tableElement.add(trAxisInfoElement);
 		}
@@ -209,74 +149,14 @@ public class JenkinsReportUtil {
 				batchName = batchName.replace(jobName + "/", "");
 			}
 
-			String batchBuildURL = batchBuild.getBuildURL();
-
-			String batchConsoleURL = batchBuildURL + "console";
-
-			String batchTestReportURL = batchBuildURL + "testReport";
-
-			long batchDuration = batchBuild.getDuration();
-
-			String batchDurationString =
-				JenkinsResultsParserUtil.toDurationString(batchDuration);
-
-			long batchStartTime = batchBuild.getStartTimestamp();
-
-			Date batchStartDate = new Date(batchStartTime);
-
-			Element batchNameElement = Dom4JUtil.getNewAnchorElement(
-				batchBuildURL, null, batchName);
-
-			Element batchConsoleElement = Dom4JUtil.getNewAnchorElement(
-				batchConsoleURL, null, "Console");
-
-			Element batchTestReportElement = Dom4JUtil.getNewAnchorElement(
-				batchTestReportURL, null, "Test Report");
-
-			Element thBatchNameElement = Dom4JUtil.getNewElement("th");
-
-			thBatchNameElement.add(batchNameElement);
-
-			Element thBatchConsoleElement = Dom4JUtil.getNewElement("th");
-
-			thBatchConsoleElement.add(batchConsoleElement);
-
-			Element thTestReportElement = Dom4JUtil.getNewElement("th");
-
-			thTestReportElement.add(batchTestReportElement);
-
-			Element thStartTimeStringElement = Dom4JUtil.getNewElement(
-				"th", null, "START TIME:");
-
-			Element thStartTimeElement = Dom4JUtil.getNewElement(
-				"th", null, batchStartDate.toLocaleString());
-
-			Element thBuildTimeStringElement = Dom4JUtil.getNewElement(
-				"th", null, "BUILD TIME:");
-
-			Element thBuildTimeElement = Dom4JUtil.getNewElement(
-				"th", null, batchDurationString);
-
-			Element thStatusResultElement = Dom4JUtil.getNewElement("th");
-
-			String status = batchBuild.getStatus();
-
-			String result = batchBuild.getResult();
-
-			if (result != null) {
-				thStatusResultElement.addText(result);
-			}
-			else {
-				thStatusResultElement.addText(status);
-			}
-
 			Element trBatchElement = Dom4JUtil.getNewElement("tr");
 
-			Dom4JUtil.addToElement(
-				trBatchElement, thBatchNameElement, thBatchConsoleElement,
-				thTestReportElement, thStartTimeStringElement,
-				thStartTimeElement, thBuildTimeStringElement,
-				thBuildTimeElement, thStatusResultElement);
+			List<Element> batchInfoElements = getCommonBuildInfoElementList(
+				batchBuild, batchName, "th");
+
+			for (Element batchInfoElement : batchInfoElements) {
+				trBatchElement.add(batchInfoElement);
+			}
 
 			tableElement.add(trBatchElement);
 
@@ -774,70 +654,14 @@ public class JenkinsReportUtil {
 
 		topLevelName = topLevelName.replace(jobName + "/", "");
 
-		String topLevelBuildURL = topLevelBuild.getBuildURL();
-
-		String topLevelConsoleURL = topLevelBuildURL + "console";
-
-		String topLevelTestReportURL = topLevelBuildURL + "testReport";
-
-		long topLevelDuration = topLevelBuild.getDuration();
-
-		String topLevelDurationString =
-			JenkinsResultsParserUtil.toDurationString(topLevelDuration);
-
-		long topLevelStartTime = topLevelBuild.getStartTimestamp();
-
-		Date topLevelStartDate = new Date(topLevelStartTime);
-
-		Element topLevelNameElement = Dom4JUtil.getNewAnchorElement(
-			topLevelBuildURL, null, topLevelName);
-
-		Element topLevelConsoleElement = Dom4JUtil.getNewAnchorElement(
-			topLevelConsoleURL, null, "Console");
-
-		Element topLevelTestReportElement = Dom4JUtil.getNewAnchorElement(
-			topLevelTestReportURL, null, "Test Report");
-
-		Element thTopLevelNameElement = Dom4JUtil.getNewElement("th");
-
-		thTopLevelNameElement.add(topLevelNameElement);
-
-		Element thTopLevelConsoleElement = Dom4JUtil.getNewElement("th");
-
-		thTopLevelConsoleElement.add(topLevelConsoleElement);
-
-		Element thTestReportElement = Dom4JUtil.getNewElement("th");
-
-		thTestReportElement.add(topLevelTestReportElement);
-
-		Element thStartTimeStringElement = Dom4JUtil.getNewElement(
-			"th", null, "START TIME:");
-
-		Element thStartTimeElement = Dom4JUtil.getNewElement(
-			"th", null, topLevelStartDate.toLocaleString());
-
-		Element thBuildTimeStringElement = Dom4JUtil.getNewElement(
-			"th", null, "BUILD TIME:");
-
-		Element thBuildTimeElement = Dom4JUtil.getNewElement(
-			"th", null, topLevelDurationString);
-
-		Element thStatusResultElement = Dom4JUtil.getNewElement("th");
-
-		if (result != null) {
-			thStatusResultElement.addText(result);
-		}
-		else {
-			thStatusResultElement.addText(status);
-		}
-
 		Element trTopLevelElement = Dom4JUtil.getNewElement("tr");
 
-		Dom4JUtil.addToElement(
-			trTopLevelElement, thTopLevelNameElement, thTopLevelConsoleElement,
-			thTestReportElement, thStartTimeStringElement, thStartTimeElement,
-			thBuildTimeStringElement, thBuildTimeElement,
-			thStatusResultElement);
+		List<Element> topLevelInfoElements = getCommonBuildInfoElementList(
+			topLevelBuild, topLevelName, "th");
+
+		for (Element topLevelInfoElement : topLevelInfoElements) {
+			trTopLevelElement.add(topLevelInfoElement);
+		}
 
 		topLevelTableElement.add(trTopLevelElement);
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsReportUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsReportUtil.java
@@ -14,84 +14,21 @@
 
 package com.liferay.jenkins.results.parser;
 
-import org.dom4j.Element;
-
 import java.io.IOException;
+
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Set;
+
+import org.dom4j.Element;
 
 /**
  * @author Kenji Heigel
  */
 public class JenkinsReportUtil {
-	public static Element getTimelineElement(
-		Build topLevelBuild, Map<String, Build> builds) {
-
-		long topLevelDuration = topLevelBuild.getDuration();
-		long topLevelStartTime = topLevelBuild.getStartTimestamp();
-
-		int dataPoints = 500;
-
-		long[] invocationData = new long[dataPoints];
-		long[] slaveUsageData = new long[dataPoints];
-
-		for (String key : builds.keySet()) {
-			Build build = builds.get(key);
-
-			long buildDuration = build.getDuration();
-			long buildStartTime = build.getStartTimestamp();
-
-			long buildEndTime = buildDuration + buildStartTime;
-
-			long dataEnd =
-				(buildEndTime - topLevelStartTime) * dataPoints /
-					topLevelDuration;
-			long dataStart =
-				(buildStartTime - topLevelStartTime) * dataPoints /
-					topLevelDuration;
-
-			for (int i = (int)dataStart; i < dataEnd; i++) {
-				slaveUsageData[i] = ++slaveUsageData[i];
-			}
-
-			invocationData[(int)dataStart] = ++invocationData[(int)dataStart];
-		}
-
-		long[] timeData = new long[dataPoints];
-
-//		timeData[0] = topLevelStartTime;
-		timeData[0] = 0;
-
-		for (int i = 1; i < timeData.length; i++) {
-			timeData[i] = timeData[0] + i * topLevelDuration / dataPoints ;
-		}
-
-		Element canvasElement = Dom4JUtil.getNewElement("canvas");
-
-		canvasElement.addAttribute("height", "300");
-		canvasElement.addAttribute("id", "timeline");
-
-		Element scriptElement = Dom4JUtil.getNewElement("script");
-
-		scriptElement.addAttribute("src", _CHART_JS_FILE);
-		scriptElement.addText("");
-
-		Element chartJSScriptElement =
-			getChartJSScriptElement(
-				Arrays.toString(timeData), Arrays.toString(slaveUsageData),
-				Arrays.toString(invocationData));
-
-		Element divElement = Dom4JUtil.getNewElement("div");
-
-		Dom4JUtil.addToElement(
-			divElement, canvasElement, scriptElement, chartJSScriptElement);
-
-		return divElement;
-	}
 
 	public static Element getBasicHeaderElement(
-	Build topLevelBuild, Map<String, Build> builds) {
+		Build topLevelBuild, Map<String, Build> builds) {
 
 		long totalTime = 0;
 
@@ -135,7 +72,7 @@ public class JenkinsReportUtil {
 			Class<?> clazz = JenkinsResultsParserUtil.class;
 
 			resource = JenkinsResultsParserUtil.readInputStream(
-			clazz.getResourceAsStream("chart-template.js"));
+				clazz.getResourceAsStream("chart-template.js"));
 		}
 		catch (IOException ioe) {
 		}
@@ -151,6 +88,71 @@ public class JenkinsReportUtil {
 		return scriptElement;
 	}
 
+	public static Element getTimelineElement(
+		Build topLevelBuild, Map<String, Build> builds) {
+
+		long topLevelDuration = topLevelBuild.getDuration();
+		long topLevelStartTime = topLevelBuild.getStartTimestamp();
+
+		int dataPoints = 500;
+
+		long[] invocationData = new long[dataPoints];
+		long[] slaveUsageData = new long[dataPoints];
+
+		for (String key : builds.keySet()) {
+			Build build = builds.get(key);
+
+			long buildDuration = build.getDuration();
+			long buildStartTime = build.getStartTimestamp();
+
+			long buildEndTime = buildDuration + buildStartTime;
+
+			long dataEnd =
+				(buildEndTime - topLevelStartTime) * dataPoints /
+					topLevelDuration;
+
+			long dataStart =
+				(buildStartTime - topLevelStartTime) * dataPoints /
+					topLevelDuration;
+
+			for (int i = (int)dataStart; i < dataEnd; i++) {
+				slaveUsageData[i] = ++slaveUsageData[i];
+			}
+
+			invocationData[(int)dataStart] = ++invocationData[(int)dataStart];
+		}
+
+		long[] timeData = new long[dataPoints];
+
+		timeData[0] = 0;
+
+		for (int i = 1; i < timeData.length; i++) {
+			timeData[i] = timeData[0] + i * topLevelDuration / dataPoints;
+		}
+
+		Element canvasElement = Dom4JUtil.getNewElement("canvas");
+
+		canvasElement.addAttribute("height", "300");
+		canvasElement.addAttribute("id", "timeline");
+
+		Element scriptElement = Dom4JUtil.getNewElement("script");
+
+		scriptElement.addAttribute("src", _CHART_JS_FILE);
+		scriptElement.addText("");
+
+		Element chartJSScriptElement = getChartJSScriptElement(
+			Arrays.toString(timeData), Arrays.toString(slaveUsageData),
+			Arrays.toString(invocationData));
+
+		Element divElement = Dom4JUtil.getNewElement("div");
+
+		Dom4JUtil.addToElement(
+			divElement, canvasElement, scriptElement, chartJSScriptElement);
+
+		return divElement;
+	}
+
 	private static final String _CHART_JS_FILE =
 		"https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.5.0/Chart.min.js";
+
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsReportUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsReportUtil.java
@@ -24,6 +24,7 @@ import org.dom4j.Element;
 
 /**
  * @author Kenji Heigel
+ * @author Yi-Chen Tsai
  */
 public class JenkinsReportUtil {
 
@@ -86,6 +87,18 @@ public class JenkinsReportUtil {
 		scriptElement.addText(resource);
 
 		return scriptElement;
+	}
+
+	public static Element getHTMLBodyElement(Build topLevelBuild) {
+		Element bodyElement = Dom4JUtil.getNewElement("body");
+
+		return bodyElement;
+	}
+
+	public static Element getHTMLHeadElement() {
+		Element headElement = Dom4JUtil.getNewElement("head");
+
+		return headElement;
 	}
 
 	public static Element getTimelineElement(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsReportUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsReportUtil.java
@@ -564,6 +564,34 @@ public class JenkinsReportUtil {
 		return divElement;
 	}
 
+	protected static Element getTableColumnHeaderElement() {
+		Element nameElement = Dom4JUtil.getNewElement("th", null, "Name");
+
+		Element consoleElement = Dom4JUtil.getNewElement("th", null, "Console");
+
+		Element testReportElement = Dom4JUtil.getNewElement(
+			"th", null, "Test Report");
+
+		Element startTimeElement = Dom4JUtil.getNewElement(
+			"th", null, "Start Time");
+
+		Element buildTimeElement = Dom4JUtil.getNewElement(
+			"th", null, "Build Time");
+
+		Element statusElement = Dom4JUtil.getNewElement("th", null, "Status");
+
+		Element resultElement = Dom4JUtil.getNewElement("th", null, "Result");
+
+		Element tableColumnHeaderElement = Dom4JUtil.getNewElement("tr");
+
+		Dom4JUtil.addToElement(
+			tableColumnHeaderElement, nameElement, consoleElement,
+			testReportElement, startTimeElement, buildTimeElement,
+			statusElement, resultElement);
+
+		return tableColumnHeaderElement;
+	}
+
 	protected static Element getTimelineElement(
 		Build topLevelBuild, Map<String, Build> builds) {
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsReportUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsReportUtil.java
@@ -24,13 +24,15 @@ import java.util.TreeMap;
 
 import org.dom4j.Element;
 
+import org.json.JSONObject;
+
 /**
  * @author Kenji Heigel
  * @author Yi-Chen Tsai
  */
 public class JenkinsReportUtil {
 
-	public static Element getHTMLBodyElement(Build topLevelBuild) {
+	public static Element getHTMLBodyElement(TopLevelBuild topLevelBuild) {
 		Map<String, Build> axisBuilds = new TreeMap<>();
 		Map<String, Build> batchBuilds = new TreeMap<>();
 		Map<String, TestResult> testResults = new TreeMap<>();
@@ -70,24 +72,24 @@ public class JenkinsReportUtil {
 
 		Element h1Element = Dom4JUtil.getNewElement("h1");
 
-		String githubReceiverUsername = topLevelBuild.getParameterValue(
-			"GITHUB_RECEIVER_USERNAME");
-
-		String githubPullRequestNumber = topLevelBuild.getParameterValue(
-			"GITHUB_PULL_REQUEST_NUMBER");
+		String buildURL = topLevelBuild.getBuildURL();
 
 		Dom4JUtil.addToElement(
-			h1Element, "Jenkins timeline for ",
-			Dom4JUtil.getNewAnchorElement(
-				topLevelBuild.getBuildURL(), topLevelBuild.getBuildURL()),
-			Dom4JUtil.getNewElement(
-				"p", null, githubReceiverUsername, " - ",
-				"PR#" + githubPullRequestNumber, " - ", "JENKINS REPORT LINK"));
+			h1Element, "Jenkins report for ",
+			Dom4JUtil.getNewAnchorElement(buildURL, buildURL));
+
+		JSONObject jobJSONObject = topLevelBuild.getBuildJSONObject();
+
+		String jobDescription = jobJSONObject.getString("description");
+
+		Element h2Element = Dom4JUtil.getNewElement("h2");
+
+		Dom4JUtil.addToElement(h2Element, jobDescription);
 
 		Element bodyElement = Dom4JUtil.getNewElement("body");
 
 		Dom4JUtil.addToElement(
-			bodyElement, h1Element,
+			bodyElement, h1Element, h2Element,
 			getSummaryElement(
 				topLevelBuild, axisBuilds, batchBuilds, testResults),
 			getTimelineElement(topLevelBuild, axisBuilds));
@@ -312,32 +314,32 @@ public class JenkinsReportUtil {
 		Build topLevelBuild, Map<String, Build> axisBuilds,
 		Map<String, Build> batchBuilds, Map<String, TestResult> testResults) {
 
-		long startTimeStamp = topLevelBuild.getStartTimestamp();
-
-		long durationTime = topLevelBuild.getDuration();
-
-		Date startTime = new Date(startTimeStamp);
-
-		Element startTimeElement = Dom4JUtil.getNewElement(
-			"p", null, "Start Time: ", startTime.toLocaleString(),
-			" - Build Time: ",
-			JenkinsResultsParserUtil.toDurationString(durationTime));
+		Element buildTimeElement = Dom4JUtil.getNewElement(
+			"p", null, "Build Time: ",
+			JenkinsResultsParserUtil.toDurationString(
+				topLevelBuild.getDuration()));
 
 		Element ciUsageElement = getTotalCIUsageElement(axisBuilds);
 
-		Element vmUsageElement = getTotalVMUSageElement(axisBuilds);
+		Element longestAxisElement = getLongestAxisElement(axisBuilds);
 
 		Element longestBatchElement = getLongestBatchElement(batchBuilds);
 
-		Element longestAxisElement = getLongestAxisElement(axisBuilds);
-
 		Element longestTestElement = getLongestTestElement(testResults);
+
+		Date startTime = new Date(topLevelBuild.getStartTimestamp());
+
+		Element startTimeElement = Dom4JUtil.getNewElement(
+			"p", null, "Start Time: ", startTime.toLocaleString());
+
+		Element vmUsageElement = getTotalVMUSageElement(axisBuilds);
 
 		Element divElement = Dom4JUtil.getNewElement("div");
 
 		Dom4JUtil.addToElement(
-			divElement, startTimeElement, ciUsageElement, vmUsageElement,
-			longestBatchElement, longestAxisElement, longestTestElement);
+			divElement, startTimeElement, buildTimeElement, ciUsageElement,
+			vmUsageElement, longestBatchElement, longestAxisElement,
+			longestTestElement);
 
 		return divElement;
 	}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsReportUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsReportUtil.java
@@ -42,41 +42,32 @@ public class JenkinsReportUtil {
 		Map<String, Build> batchBuilds = new TreeMap<>();
 		Map<String, TestResult> testResults = new TreeMap<>();
 
-		try {
-			for (Build batchBuild : topLevelBuild.getDownstreamBuilds(null)) {
-				batchBuilds.put(batchBuild.getDisplayName(), batchBuild);
+		for (Build batchBuild : topLevelBuild.getDownstreamBuilds(null)) {
+			String batchBuildDisplayName = batchBuild.getDisplayName();
 
-				for (Build axisBuild : batchBuild.getDownstreamBuilds(null)) {
-					try {
-						String axisKey =
-							batchBuild.getDisplayName() + "/" +
-								JenkinsResultsParserUtil.getAxisVariable(
-									axisBuild.getBuildURL());
+			if (batchBuildDisplayName == null) {
+				return null;
+			}
 
-						axisBuilds.put(axisKey, axisBuild);
-					}
-					catch (Exception e) {
-						e.printStackTrace();
-					}
+			batchBuilds.put(batchBuild.getDisplayName(), batchBuild);
 
-					for (TestResult testResult :
-							axisBuild.getTestResults(null)) {
+			for (Build axisBuild : batchBuild.getDownstreamBuilds(null)) {
+				String axisKey =
+					batchBuild.getDisplayName() + "/" +
+						JenkinsResultsParserUtil.getAxisVariable(
+							axisBuild.getBuildURL());
 
-						try {
-							testResults.put(
-								testResult.getDisplayName(), testResult);
-						}
-						catch (NullPointerException npe) {
-							npe.printStackTrace();
-						}
+				axisBuilds.put(axisKey, axisBuild);
+
+				for (TestResult testResult : axisBuild.getTestResults(null)) {
+					String displayName = testResult.getDisplayName();
+
+					if (displayName != null) {
+						testResults.put(
+							testResult.getDisplayName(), testResult);
 					}
 				}
 			}
-		}
-		catch (NullPointerException npe) {
-			npe.printStackTrace();
-
-			return null;
 		}
 
 		Element h1Element = Dom4JUtil.getNewElement("h1");

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsReportUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsReportUtil.java
@@ -152,22 +152,21 @@ public class JenkinsReportUtil {
 	}
 
 	protected static void addAxisInfoToTableElement(
-		List<Build> axisBuilds, Element tableElement) {
+		List<Build> builds, Element tableElement) {
 
-		for (Build axisBuild : axisBuilds) {
+		for (Build build : builds) {
+			if (!(build instanceof AxisBuild)) {
+				continue;
+			}
+
 			String axisName = "AXIS_VARIABLE=";
 
-			try {
-				axisName = axisName + ((AxisBuild)axisBuild).getAxisNumber();
-			}
-			catch (ClassCastException cce) {
-				cce.printStackTrace();
-			}
+			axisName = axisName + ((AxisBuild)build).getAxisNumber();
 
 			Element trAxisInfoElement = Dom4JUtil.getNewElement("tr");
 
 			List<Element> axisInfoElements = getCommonBuildInfoElementList(
-				axisBuild, axisName, "td");
+				build, axisName, "td");
 
 			for (Element axisInfoElement : axisInfoElements) {
 				trAxisInfoElement.add(axisInfoElement);

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsReportUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsReportUtil.java
@@ -88,7 +88,7 @@ public class JenkinsReportUtil {
 
 		Dom4JUtil.addToElement(
 			bodyElement, h1Element,
-			getBasicHeaderElement(
+			getSummaryElement(
 				topLevelBuild, axisBuilds, batchBuilds, testResults),
 			getTimelineElement(topLevelBuild, axisBuilds));
 
@@ -99,40 +99,6 @@ public class JenkinsReportUtil {
 		Element headElement = Dom4JUtil.getNewElement("head");
 
 		return headElement;
-	}
-
-	protected static Element getBasicHeaderElement(
-		Build topLevelBuild, Map<String, Build> axisBuilds,
-		Map<String, Build> batchBuilds, Map<String, TestResult> testResults) {
-
-		long startTimeStamp = topLevelBuild.getStartTimestamp();
-
-		long durationTime = topLevelBuild.getDuration();
-
-		Date startTime = new Date(startTimeStamp);
-
-		Element startTimeElement = Dom4JUtil.getNewElement(
-			"p", null, "Start Time: ", startTime.toLocaleString(),
-			" - Build Time: ",
-			JenkinsResultsParserUtil.toDurationString(durationTime));
-
-		Element ciUsageElement = getTotalCIUsageElement(axisBuilds);
-
-		Element vmUsageElement = getTotalVMUSageElement(axisBuilds);
-
-		Element longestBatchElement = getLongestBatchElement(batchBuilds);
-
-		Element longestAxisElement = getLongestAxisElement(axisBuilds);
-
-		Element longestTestElement = getLongestTestElement(testResults);
-
-		Element divElement = Dom4JUtil.getNewElement("div");
-
-		Dom4JUtil.addToElement(
-			divElement, startTimeElement, ciUsageElement, vmUsageElement,
-			longestBatchElement, longestAxisElement, longestTestElement);
-
-		return divElement;
 	}
 
 	protected static Element getBatchReportElement(
@@ -340,6 +306,40 @@ public class JenkinsReportUtil {
 			JenkinsResultsParserUtil.toDurationString(longestTestDuration));
 
 		return longestTestElement;
+	}
+
+	protected static Element getSummaryElement(
+		Build topLevelBuild, Map<String, Build> axisBuilds,
+		Map<String, Build> batchBuilds, Map<String, TestResult> testResults) {
+
+		long startTimeStamp = topLevelBuild.getStartTimestamp();
+
+		long durationTime = topLevelBuild.getDuration();
+
+		Date startTime = new Date(startTimeStamp);
+
+		Element startTimeElement = Dom4JUtil.getNewElement(
+			"p", null, "Start Time: ", startTime.toLocaleString(),
+			" - Build Time: ",
+			JenkinsResultsParserUtil.toDurationString(durationTime));
+
+		Element ciUsageElement = getTotalCIUsageElement(axisBuilds);
+
+		Element vmUsageElement = getTotalVMUSageElement(axisBuilds);
+
+		Element longestBatchElement = getLongestBatchElement(batchBuilds);
+
+		Element longestAxisElement = getLongestAxisElement(axisBuilds);
+
+		Element longestTestElement = getLongestTestElement(testResults);
+
+		Element divElement = Dom4JUtil.getNewElement("div");
+
+		Dom4JUtil.addToElement(
+			divElement, startTimeElement, ciUsageElement, vmUsageElement,
+			longestBatchElement, longestAxisElement, longestTestElement);
+
+		return divElement;
 	}
 
 	protected static Element getTimelineElement(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsReportUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsReportUtil.java
@@ -29,67 +29,6 @@ import org.dom4j.Element;
  */
 public class JenkinsReportUtil {
 
-	public static Element getBasicHeaderElement(
-		Build topLevelBuild, Map<String, Build> builds) {
-
-		long totalTime = 0;
-
-		for (Build axisBuild : builds.values()) {
-			totalTime = totalTime + axisBuild.getDuration();
-		}
-
-		Element divElement = Dom4JUtil.getNewElement("div");
-
-		long hoursTotalTime = totalTime / 3600000;
-
-		divElement.addText(
-			"Total CI Usage: " + hoursTotalTime + " server hours");
-
-		return divElement;
-	}
-
-	public static Element getBatchReportElement(
-		Build topLevelBuild, Map<String, Build> builds) {
-
-		Set<String> buildsKeySet = builds.keySet();
-
-		for (String key : buildsKeySet) {
-			Build build = builds.get(key);
-
-			long buildDuration = build.getDuration();
-			long buildStartTime = build.getStartTimestamp();
-
-			long buildEndTime = buildDuration + buildStartTime;
-		}
-
-		return null;
-	}
-
-	public static Element getChartJSScriptElement(
-		String xData, String y1Data, String y2Data) {
-
-		String resource = null;
-
-		try {
-			Class<?> clazz = JenkinsResultsParserUtil.class;
-
-			resource = JenkinsResultsParserUtil.readInputStream(
-				clazz.getResourceAsStream("chart-template.js"));
-		}
-		catch (IOException ioe) {
-		}
-
-		resource = resource.replace("'xData'", xData);
-		resource = resource.replace("'y1Data'", y1Data);
-		resource = resource.replace("'y2Data'", y2Data);
-
-		Element scriptElement = Dom4JUtil.getNewElement("script");
-
-		scriptElement.addText(resource);
-
-		return scriptElement;
-	}
-
 	public static Element getHTMLBodyElement(Build topLevelBuild) {
 		Map<String, Build> axisBuilds = new TreeMap<>();
 		Map<String, Build> batchBuilds = new TreeMap<>();
@@ -160,7 +99,68 @@ public class JenkinsReportUtil {
 		return headElement;
 	}
 
-	public static Element getTimelineElement(
+	protected static Element getBasicHeaderElement(
+		Build topLevelBuild, Map<String, Build> builds) {
+
+		long totalTime = 0;
+
+		for (Build axisBuild : builds.values()) {
+			totalTime = totalTime + axisBuild.getDuration();
+		}
+
+		Element divElement = Dom4JUtil.getNewElement("div");
+
+		long hoursTotalTime = totalTime / 3600000;
+
+		divElement.addText(
+			"Total CI Usage: " + hoursTotalTime + " server hours");
+
+		return divElement;
+	}
+
+	protected static Element getBatchReportElement(
+		Build topLevelBuild, Map<String, Build> builds) {
+
+		Set<String> buildsKeySet = builds.keySet();
+
+		for (String key : buildsKeySet) {
+			Build build = builds.get(key);
+
+			long buildDuration = build.getDuration();
+			long buildStartTime = build.getStartTimestamp();
+
+			long buildEndTime = buildDuration + buildStartTime;
+		}
+
+		return null;
+	}
+
+	protected static Element getChartJSScriptElement(
+		String xData, String y1Data, String y2Data) {
+
+		String resource = null;
+
+		try {
+			Class<?> clazz = JenkinsResultsParserUtil.class;
+
+			resource = JenkinsResultsParserUtil.readInputStream(
+				clazz.getResourceAsStream("chart-template.js"));
+		}
+		catch (IOException ioe) {
+		}
+
+		resource = resource.replace("'xData'", xData);
+		resource = resource.replace("'y1Data'", y1Data);
+		resource = resource.replace("'y2Data'", y2Data);
+
+		Element scriptElement = Dom4JUtil.getNewElement("script");
+
+		scriptElement.addText(resource);
+
+		return scriptElement;
+	}
+
+	protected static Element getTimelineElement(
 		Build topLevelBuild, Map<String, Build> builds) {
 
 		long topLevelDuration = topLevelBuild.getDuration();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsReportUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsReportUtil.java
@@ -28,6 +28,7 @@ import org.apache.commons.lang.StringUtils;
 
 import org.dom4j.Element;
 
+import org.json.JSONException;
 import org.json.JSONObject;
 
 /**
@@ -55,6 +56,7 @@ public class JenkinsReportUtil {
 						axisBuilds.put(axisKey, axisBuild);
 					}
 					catch (Exception e) {
+						e.printStackTrace();
 					}
 
 					for (TestResult testResult :
@@ -64,13 +66,16 @@ public class JenkinsReportUtil {
 							testResults.put(
 								testResult.getDisplayName(), testResult);
 						}
-						catch (Exception e) {
+						catch (NullPointerException npe) {
+							npe.printStackTrace();
 						}
 					}
 				}
 			}
 		}
-		catch (Exception e) {
+		catch (NullPointerException npe) {
+			npe.printStackTrace();
+
 			return null;
 		}
 
@@ -84,7 +89,14 @@ public class JenkinsReportUtil {
 
 		JSONObject jobJSONObject = topLevelBuild.getBuildJSONObject();
 
-		String jobDescription = jobJSONObject.getString("description");
+		String jobDescription = "";
+
+		try {
+			jobDescription = jobJSONObject.getString("description");
+		}
+		catch (JSONException jsone) {
+			jsone.printStackTrace();
+		}
 
 		Element h2Element = Dom4JUtil.getNewElement("h2");
 
@@ -152,8 +164,14 @@ public class JenkinsReportUtil {
 		List<Build> axisBuilds, Element tableElement) {
 
 		for (Build axisBuild : axisBuilds) {
-			String axisName =
-				"AXIS_VARIABLE=" + ((AxisBuild)axisBuild).getAxisNumber();
+			String axisName = "AXIS_VARIABLE=";
+
+			try {
+				axisName = axisName + ((AxisBuild)axisBuild).getAxisNumber();
+			}
+			catch (ClassCastException cce) {
+				cce.printStackTrace();
+			}
 
 			Element trAxisInfoElement = Dom4JUtil.getNewElement("tr");
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -481,8 +481,15 @@ public class JenkinsResultsParserUtil {
 		return "";
 	}
 
-	public static String getAxisVariable(String axisBuildURL) throws Exception {
-		String url = decode(axisBuildURL);
+	public static String getAxisVariable(String axisBuildURL) {
+		String url = null;
+
+		try {
+			url = decode(axisBuildURL);
+		}
+		catch (UnsupportedEncodingException uee) {
+			throw new RuntimeException("Unable to encode " + axisBuildURL);
+		}
 
 		String label = "AXIS_VARIABLE=";
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -39,8 +39,11 @@ import java.net.UnknownHostException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
+import java.text.SimpleDateFormat;
+
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.LinkedHashMap;
@@ -926,6 +929,12 @@ public class JenkinsResultsParserUtil {
 		String jenkinsMasterName, String offlineReason, String... slaveNames) {
 
 		_setSlaveStatus(jenkinsMasterName, offlineReason, false, slaveNames);
+	}
+
+	public static String toDateString(Date date) {
+		SimpleDateFormat sdf = new SimpleDateFormat("MMM dd, yyyy h:mm:ss a z");
+
+		return sdf.format(date);
 	}
 
 	public static String toDurationString(long duration) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TopLevelBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TopLevelBuild.java
@@ -26,10 +26,12 @@ import java.io.StringWriter;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.regex.Matcher;
@@ -140,6 +142,53 @@ public class TopLevelBuild extends BaseBuild {
 		catch (IOException ioe) {
 			throw new RuntimeException("Unable to get Jenkins report", ioe);
 		}
+	}
+
+	@Override
+	public Element getJenkinsReportElement() {
+		Map<String, Build> axisBuilds = new TreeMap<>();
+		Map<String, Build> batchBuilds = new TreeMap<>();
+
+		try {
+			for (Build batchBuild : getDownstreamBuilds(null)) {
+				batchBuilds.put(batchBuild.getDisplayName(), batchBuild);
+
+				for (Build axisBuild : batchBuild.getDownstreamBuilds(null)) {
+					String key = null;
+
+					try {
+						key = batchBuild.getDisplayName() + "/" +
+						JenkinsResultsParserUtil.getAxisVariable(
+						axisBuild.getBuildURL());
+					}
+					catch (Exception e) {
+					}
+
+					axisBuilds.put(key, axisBuild);
+				}
+			}
+
+			Element divElement = Dom4JUtil.getNewElement("div");
+
+			Element h3Element = Dom4JUtil.getNewElement("h3");
+
+			Dom4JUtil.addToElement(
+				h3Element, "Jenkins timeline for ",
+				Dom4JUtil.getNewAnchorElement(
+					this.getBuildURL(), this.getBuildURL()));
+
+			Dom4JUtil.addToElement(
+				divElement, h3Element,
+				JenkinsReportUtil.getBasicHeaderElement(this, axisBuilds),
+				JenkinsReportUtil.getTimelineElement(this, axisBuilds));
+
+			return divElement;
+		}
+		catch (Exception e)
+		{
+		}
+
+		return null;
 	}
 
 	public String getJenkinsReportURL() {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TopLevelBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TopLevelBuild.java
@@ -26,7 +26,6 @@ import java.io.StringWriter;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -157,9 +156,10 @@ public class TopLevelBuild extends BaseBuild {
 					String key = null;
 
 					try {
-						key = batchBuild.getDisplayName() + "/" +
-						JenkinsResultsParserUtil.getAxisVariable(
-						axisBuild.getBuildURL());
+						key =
+							batchBuild.getDisplayName() + "/" +
+								JenkinsResultsParserUtil.getAxisVariable(
+									axisBuild.getBuildURL());
 					}
 					catch (Exception e) {
 					}
@@ -174,8 +174,7 @@ public class TopLevelBuild extends BaseBuild {
 
 			Dom4JUtil.addToElement(
 				h3Element, "Jenkins timeline for ",
-				Dom4JUtil.getNewAnchorElement(
-					this.getBuildURL(), this.getBuildURL()));
+				Dom4JUtil.getNewAnchorElement(getBuildURL(), getBuildURL()));
 
 			Dom4JUtil.addToElement(
 				divElement, h3Element,
@@ -184,8 +183,7 @@ public class TopLevelBuild extends BaseBuild {
 
 			return divElement;
 		}
-		catch (Exception e)
-		{
+		catch (Exception e) {
 		}
 
 		return null;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TopLevelBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TopLevelBuild.java
@@ -30,7 +30,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-import java.util.TreeMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.regex.Matcher;
@@ -145,48 +144,15 @@ public class TopLevelBuild extends BaseBuild {
 
 	@Override
 	public Element getJenkinsReportElement() {
-		Map<String, Build> axisBuilds = new TreeMap<>();
-		Map<String, Build> batchBuilds = new TreeMap<>();
+		Element headElement = JenkinsReportUtil.getHTMLHeadElement();
 
-		try {
-			for (Build batchBuild : getDownstreamBuilds(null)) {
-				batchBuilds.put(batchBuild.getDisplayName(), batchBuild);
+		Element bodyElement = JenkinsReportUtil.getHTMLBodyElement(this);
 
-				for (Build axisBuild : batchBuild.getDownstreamBuilds(null)) {
-					String key = null;
+		Element jenkinsReportElement = Dom4JUtil.getNewElement("html");
 
-					try {
-						key =
-							batchBuild.getDisplayName() + "/" +
-								JenkinsResultsParserUtil.getAxisVariable(
-									axisBuild.getBuildURL());
-					}
-					catch (Exception e) {
-					}
+		Dom4JUtil.addToElement(jenkinsReportElement, headElement, bodyElement);
 
-					axisBuilds.put(key, axisBuild);
-				}
-			}
-
-			Element divElement = Dom4JUtil.getNewElement("div");
-
-			Element h3Element = Dom4JUtil.getNewElement("h3");
-
-			Dom4JUtil.addToElement(
-				h3Element, "Jenkins timeline for ",
-				Dom4JUtil.getNewAnchorElement(getBuildURL(), getBuildURL()));
-
-			Dom4JUtil.addToElement(
-				divElement, h3Element,
-				JenkinsReportUtil.getBasicHeaderElement(this, axisBuilds),
-				JenkinsReportUtil.getTimelineElement(this, axisBuilds));
-
-			return divElement;
-		}
-		catch (Exception e) {
-		}
-
-		return null;
+		return jenkinsReportElement;
 	}
 
 	public String getJenkinsReportURL() {

--- a/modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/chart-template.js
+++ b/modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/chart-template.js
@@ -1,0 +1,64 @@
+
+var ctx = document.getElementById("timeline");
+var timeline = new Chart(ctx, {
+	data: {
+		labels: 'xData',
+		datasets: [{
+			backgroundColor: 'rgba(255, 99, 132, 0.3)',
+			borderWidth: 0,
+			data: 'y1Data',
+			label: 'Jenkins Slaves in Use'
+		}, {
+            backgroundColor: 'rgba(54, 162, 235, 1)',
+            borderWidth: 0,
+            data: 'y2Data',
+            label: 'Axis Invocations'
+        }]
+	},
+	options: {
+	    elements: {
+            point: {
+                hitRadius: 10,
+                hoverRadius: 4,
+                radius: 0
+            }
+        },
+		maintainAspectRatio: false,
+		responsive: true,
+		scales: {
+			xAxes: [{
+			    scaleLabel: {
+			        display: true, labelString: 'Elapsed Time (hh:mm:ss)'
+			    },
+				ticks: {
+					autoSkipPadding: 50,
+					callback: function(value) {
+					    var time = new Date(value);
+
+                        var hours = time.getUTCHours().toString();
+                        var minutes = time.getUTCMinutes().toString();
+                        var seconds = time.getUTCSeconds().toString();
+
+                        if (hours.length == 1) {
+                             hours = '0' + hours;
+                        }
+                        if (minutes.length == 1) {
+                             minutes = '0' + minutes;
+                        }
+                        if (seconds.length == 1) {
+                             seconds = '0' + seconds;
+                        }
+
+						return hours + ':' + minutes + ':' + seconds;
+					}
+				}
+			}],
+			yAxes: [{
+				ticks: {
+					beginAtZero: true
+				}
+			}]
+		}
+	},
+	type: 'line'
+});

--- a/modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/chart-template.js
+++ b/modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/chart-template.js
@@ -1,63 +1,81 @@
-
 var ctx = document.getElementById("timeline");
+
 var timeline = new Chart(ctx, {
 	data: {
 		labels: 'xData',
-		datasets: [{
-			backgroundColor: 'rgba(255, 99, 132, 0.3)',
-			borderWidth: 0,
-			data: 'y1Data',
-			label: 'Jenkins Slaves in Use'
-		}, {
-            backgroundColor: 'rgba(54, 162, 235, 1)',
-            borderWidth: 0,
-            data: 'y2Data',
-            label: 'Axis Invocations'
-        }]
+		datasets: [
+			{
+				backgroundColor: 'rgba(255, 99, 132, 0.3)',
+				borderWidth: 0,
+				data: 'y1Data',
+				label: 'Jenkins Slaves in Use'
+			},
+			{
+				backgroundColor: 'rgba(54, 162, 235, 1)',
+				borderWidth: 0,
+				data: 'y2Data',
+				label: 'Axis Invocations'
+			}
+		]
 	},
 	options: {
-	    elements: {
-            point: {
-                hitRadius: 10,
-                hoverRadius: 4,
-                radius: 0
-            }
-        },
+		elements: {
+			point: {
+				hitRadius: 10,
+				hoverRadius: 4,
+				radius: 0
+			}
+		},
 		maintainAspectRatio: false,
 		responsive: true,
 		scales: {
-			xAxes: [{
-			    scaleLabel: {
-			        display: true, labelString: 'Elapsed Time (hh:mm:ss)'
-			    },
-				ticks: {
-					autoSkipPadding: 50,
-					callback: function(value) {
-					    var time = new Date(value);
+			xAxes: [
+				{
+					scaleLabel: {
+						display: true,
+						labelString: 'Elapsed Time (hh:mm:ss)'
+					},
+					ticks: {
+						autoSkipPadding: 50,
+						callback: function(value) {
+							var time = new Date(value);
 
-                        var hours = time.getUTCHours().toString();
-                        var minutes = time.getUTCMinutes().toString();
-                        var seconds = time.getUTCSeconds().toString();
+							var hours = time.getUTCHours();
 
-                        if (hours.length == 1) {
-                             hours = '0' + hours;
-                        }
-                        if (minutes.length == 1) {
-                             minutes = '0' + minutes;
-                        }
-                        if (seconds.length == 1) {
-                             seconds = '0' + seconds;
-                        }
+							hours = hours.toString();
 
-						return hours + ':' + minutes + ':' + seconds;
+							var minutes = time.getUTCMinutes();
+
+							minutes = minutes.toString();
+
+							var seconds = time.getUTCSeconds();
+
+							seconds = seconds.toString();
+
+							if (hours.length == 1) {
+								 hours = '0' + hours;
+							}
+
+							if (minutes.length == 1) {
+								 minutes = '0' + minutes;
+							}
+
+							if (seconds.length == 1) {
+								 seconds = '0' + seconds;
+							}
+
+							return hours + ':' + minutes + ':' + seconds;
+						 }
 					}
 				}
-			}],
-			yAxes: [{
-				ticks: {
-					beginAtZero: true
+			],
+			yAxes: [
+				{
+					ticks: {
+						beginAtZero: true
+					}
 				}
-			}]
+			]
 		}
 	},
 	type: 'line'


### PR DESCRIPTION
I made some commits while working through the code and made some notes on what is left to be done. Overall, I found that everything in JenkinsReportUtil actually belongs in the various build object model classes. Review my changes, they provide some examples of ways to tighten up the code and my notes should illustrate how to integrate the Jenkins report logic into the build object model. Let me know if you want to go over these in person..


- Move JenkinsReportUtil.getHTMLBodyElement() -> TopLevelBuild.getJenkinsReportBodyElement()

- Move JenkinsReportUtil.getHTMLHeaderElement() -> TopLevelBuild.getJenkinsReportHeadElement()

- Move JenkinsReportUtil.getBatchInfoTableElement() -> BatchBuild.getJenkinsReportTableElement()

- Move JenkinsReportUtil.getBatchReportElement() -> BatchBuild.getJenkinsReportElement()

- Move JenkinsReportUtil.getChartJSScriptElement() -> TopLevelBuild.getJenkinsReportChartJsScriptElement()

- Move JenkinsReportUtil.getCommonBuildInfoElements() -> BaseBuild.getJenkinsReportBuildInfoElement() - _Note: I changed Elements -> Element. There should be methods in BatchBuild and (maybe?) TopLevelBuild that calls this method on each downstream build_

- Move JenkinsReportUtil.getDownstreamBuildInfoElements() -> AxisBuild.getJenkinsReportBuildInfoElement() - _Note: This method should override the BaseBuild version and then call super.getBuildInfoElement() method_

- Move JenkinsReportUtil.getLongestAxisElement() -> BaseBuild.getLongestRunningDownstreamBuild() AND BaseBuild.getJenkinsReportBuildInfoElement - _Note: This method should compare the longest running downstream top-level and axis builds. Batch build run lengths should be ignored but this method should call itself recursively on Batch builds it encounters downstream._

- Move JenkinsReportUtil.getLongestBatchElement() -> TopLevelBuild.getLongestRunningBatchBuild()

- Move JenkinsReportUtil.getLongestTestElement() -> BaseBuild.getLongestRunningTestElement() - _Note: This method should have different implementations at the top-level, batch, and axis levels_

- Move JenkinsReportUtil.getSummaryElement() -> TopLevelBuild.getJenkinsReportSummaryElement()

- Move JenkinsReportUtil.getTableColumnHeaderElement() -> BaseBuild.getJenkinsReportTableColumnHeaderElement()

- Move JenkinsReportUtil.getTimelineElement() -> TopLevelBuild.getJenkinsReportTimelineElement()

- Move JenkinsReportUtil.getTopLevelTableElement() -> TopLevelBuild.getJenkinsReportTableElement()

- Move JenkinsReportUtil.getTotalCIUsageElement() -> TopLevelBuild.getJenkinsReportTotalCIUsageElement()

- Move JenkinsReportUtil.getTotalVMUsageElement() -> TopLevelBuild.getJenkinsReportTotalVMUsageElement()

- Need to make better use of Dom4JUtil to make code more concise.

- Use JenkinsResultsParserUtil.toDateString() instead of (deprecated) Date.toLocaleString
