### PR TITLE
LRCI-1506 Add supported versions property for jboss

### DIFF
--- a/app.server.properties
+++ b/app.server.properties
@@ -34,6 +34,7 @@
 ##
 
     app.server.jboss.version=7.2.0
+    app.server.jboss.supported.versions=7.2.0,7.3.0
     app.server.jboss.dir=${app.server.parent.dir}/jboss-eap-${app.server.jboss.version}
     app.server.jboss.bin.dir=${app.server.jboss.dir}/bin
     app.server.jboss.classes.global.dir=${app.server.jboss.dir}/modules/com/liferay/portal/main


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-1506

This is for `master` only.
Tested `jboss 7.3.0` here: https://github.com/yichenroy/liferay-portal/pull/459

cc @zhangyan0701 @vicnate5