### PR TITLE
LRCI-1835 Use patching tool 3.0 for 7.3.x+ versions

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -5516,7 +5516,7 @@
     build.test.results.xml=true
     dummy.socket.proxy=-DsocksProxyHost=127.0.0.1 -DsocksProxyPort=8888 -Dhttp.nonProxyHosts="accounts.google.com|www.googleapis.com"
     #ip.address=
-    patching.tool.latest.txt=LATEST-2.0.txt
+    patching.tool.latest.txt=LATEST-3.0.txt
     #print.java.process.on.fail=
     selenium.output.dir.name=${liferay.home}/poshi
     #setx.executable=


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-1835

Please backport to `7.3.x` only, this does not apply to 7.2.x or below.

fyi @brianwulbern